### PR TITLE
[SECENG-364] Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0


### PR DESCRIPTION
## Ticket
[SECENG-364](https://hoverinc.atlassian.net/browse/SECENG-364)

## Summary

Pin all GitHub Actions to commit SHAs for supply chain security. Branch-pinned actions (`@main` / `@master`) are upgraded to the repo's latest release tag.

### Pinned Actions

  - `actions/checkout@v6.0.2` → [`de0fac2e`](https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd)


[SECENG-364]: https://hoverinc.atlassian.net/browse/SECENG-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ